### PR TITLE
Remove 6th asterisk if no expression is provided

### DIFF
--- a/src/Traits/HasFrequencies.php
+++ b/src/Traits/HasFrequencies.php
@@ -94,7 +94,7 @@ trait HasFrequencies
     public function getCronExpression()
     {
         if (! $this->expression) {
-            $this->expression = '* * * * * *';
+            $this->expression = '* * * * *';
 
             foreach ($this->frequencies as $frequency) {
                 call_user_func_array([$this, $frequency->interval], $frequency->parameters->pluck('value')->toArray());


### PR DESCRIPTION
The underlying Cron FieldFactory (https://github.com/dragonmantank/cron-expression/blob/2a88eac648d209199d5d2d660d1f20c53583de5b/src/Cron/FieldFactory.php#L26) does not support year parameter.